### PR TITLE
BUG: gdb was not able to detect _start symbol

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -21,11 +21,13 @@ $(SUBDIR):
 
 build: $(SUBDIR)
 	echo "kernel building"
-	i686-elf-ld -g -relocatable $(BUILD_DIRECTORY)/*.o -o $(BUILD_DIRECTORY)/$(COMPLETE_KERNEL_OBJ)
+#necessary to place kernel.asm.o first in the relocatable object file palcement so that 0x100000 should be _start
+	i686-elf-ld -g -relocatable $(BUILD_DIRECTORY)/kernel_asm/kernel.asm.o $(BUILD_DIRECTORY)/*.o -o $(BUILD_DIRECTORY)/$(COMPLETE_KERNEL_OBJ)
 	i686-elf-gcc $(FLAGS) -T $(SRC_DIRECTORY)/linker.ld -o $(BIN_DIRECTORY)/$(COMPLETE_KERNEL_BIN) -ffreestanding -nostdlib $(BUILD_DIRECTORY)/kernelfull.o
 
 clean:
 	rm -rf $(BUILD_DIRECTORY)/*.o
+	rm -rf $(BUILD_DIRECTORY)/kernel_asm/
 	rm -rf $(BIN_DIRECTORY)/*.bin
 
 #disassemble the bootloader binary

--- a/src/kernel/Makefile
+++ b/src/kernel/Makefile
@@ -6,13 +6,14 @@ DIRECTORY = .
 #Find all .c and .asm files in all the directories found
 SRC_FILES = $(foreach d,$(DIRECTORY),$(shell find $(d) -name *.c -or -name *.asm))
 #create object file names by subsituting extensions with .o , using filter helps to substitute multiple files with different patterns
-OBJ_FILES = $(filter %.o,$(patsubst %.asm,%.asm.o,$(SRC_FILES)) $(patsubst %.c,%.o,$(SRC_FILES)))
+OBJ_FILES = $(filter %.o, $(patsubst %.c,%.o,$(SRC_FILES)))
+ASM_FILES = $(filter %.asm.o, $(patsubst %.asm,%.asm.o,$(SRC_FILES)))
 # #extract the file name from the absolute file paths
 # FILES = $(foreach d,$(OBJ_FILES),$(shell basename $(d)))
 
 all: compile pre_install clean
 
-compile: $(OBJ_FILES)
+compile: $(OBJ_FILES) $(ASM_FILES)
 
 # .asm compilation
 %.asm.o: %.asm
@@ -27,8 +28,13 @@ pre_install:
         cp -rfv $$file $(BUILD_DIRECTORY)/. ; \
     done
 
+	mkdir -p $(BUILD_DIRECTORY)/kernel_asm
+	for file in $(ASM_FILES); do \
+        cp -rfv $$file $(BUILD_DIRECTORY)/kernel_asm/. ; \
+    done
+
 clean:
-	rm -rf $(OBJ_FILES)
+	rm -rf $(OBJ_FILES) $(ASM_FILES)
 
 #disassemble the bootloader binary
 open: dis

--- a/src/kernel/kernel.asm
+++ b/src/kernel/kernel.asm
@@ -1,6 +1,6 @@
 [BITS 32]
 
-section .kernel.asm ; seperating kernel asm section, commented as were not able to get debugging symbol _start
+; section .kernel.asm ; seperating kernel asm section, commented as were not able to get debugging symbol _start
 
 global _start
 global raise_int_zero

--- a/src/linker.ld
+++ b/src/linker.ld
@@ -3,10 +3,7 @@ OUTPUT_FORMAT(binary)
 SECTIONS
 {
     . = 1M;
-    .kernel.asm : ALIGN(4096)
-    {
-        *(.kernel.asm)
-    }
+    
     .text : ALIGN(4096)
     {
         *(.text)


### PR DESCRIPTION
- since kernel.asm was present in kernel_asm section, so symbols were
not getting detected by gdb, although code execution was proper. So I
guess symbols needs to be in .text section

- made changes in makefile as well so that kernel.asm.o to be relocate
first so that it linked first in the final kernel.bin